### PR TITLE
TP-Link MR3/4XXX nach WDR umbenannt

### DIFF
--- a/source/download.haml
+++ b/source/download.haml
@@ -65,32 +65,32 @@ title: Download - Freifunk Düsseldorf
 .row
   .col-md-2
     %p.lead
-      TL-MR3500
+      TL-WA830
+  .col-md-1
+    %a.btn.btn-default( href="http://images.freifunk-rheinland.net/images/gluon/duesseldorf/2015.1.2-stable-5/factory/gluon-ddorf-2015.1.2-stable-5-tp-link-tl-wa830re-v1.bin" ) Revision 1
+  .col-md-1
+    %a.btn.btn-default( href="http://images.freifunk-rheinland.net/images/gluon/duesseldorf/2015.1.2-stable-5/factory/gluon-ddorf-2015.1.2-stable-5-tp-link-tl-wa830re-v2.bin" ) Revision 2
+
+.row
+  .col-md-2
+    %p.lead
+      TL-WDR3500
   .col-md-1
     %a.btn.btn-default( href="http://images.freifunk-rheinland.net/images/gluon/duesseldorf/stable/factory/gluon-ddorf-2015.1.2-stable-5-tp-link-tl-wdr3500-v1.bin" ) Revision 1
 
 .row
   .col-md-2
     %p.lead
-      TL-MR3600
+      TL-WDR3600
   .col-md-1
     %a.btn.btn-default( href="http://images.freifunk-rheinland.net/images/gluon/duesseldorf/stable/factory/gluon-ddorf-2015.1.2-stable-5-tp-link-tl-wdr3600-v1.bin" ) Revision 1
 
 .row
   .col-md-2
     %p.lead
-      TL-MR4300
+      TL-WDR4300
   .col-md-1
     %a.btn.btn-default( href="http://images.freifunk-rheinland.net/images/gluon/duesseldorf/stable/factory/gluon-ddorf-2015.1.2-stable-5-tp-link-tl-wdr4300-v1.bin" ) Revision 1
-
-.row
-  .col-md-2
-    %p.lead
-      TL-WA830
-  .col-md-1
-    %a.btn.btn-default( href="http://images.freifunk-rheinland.net/images/gluon/duesseldorf/2015.1.2-stable-5/factory/gluon-ddorf-2015.1.2-stable-5-tp-link-tl-wa830re-v1.bin" ) Revision 1
-  .col-md-1
-    %a.btn.btn-default( href="http://images.freifunk-rheinland.net/images/gluon/duesseldorf/2015.1.2-stable-5/factory/gluon-ddorf-2015.1.2-stable-5-tp-link-tl-wa830re-v2.bin" ) Revision 2
 
 .row
   .col-md-2


### PR DESCRIPTION
Wrong naming of some TP-Link WDR devices. See https://forum.freifunk.net/t/router-firmware-download-namen/9757
